### PR TITLE
Tech-377

### DIFF
--- a/packages/cron/prisma/schema.prisma
+++ b/packages/cron/prisma/schema.prisma
@@ -9,6 +9,7 @@ datasource db {
 
 model Email {
   id        Int      @id @default(autoincrement())
+  uid       String   @unique
   email     String
   template  String   @default("")
   status    String   @default("pending")
@@ -20,6 +21,7 @@ model Email {
 
 model Submission {
   id        Int      @id @default(autoincrement())
+  uid       String   @unique
   email     String
   createdAt DateTime @default(now())
   action    String   @default("")

--- a/packages/cron/src/services/email.service.ts
+++ b/packages/cron/src/services/email.service.ts
@@ -70,7 +70,7 @@ const sendEmail = async (chesToken: string, recipient: Email): Promise<AxiosResp
     try {
         // fill in the correct email template with recipient's information
         const { catchment } = recipient
-        const uid = encodeURIComponent(recipient.id)
+        const uid = encodeURIComponent(recipient.uid)
         let body = ""
 
         // form link

--- a/packages/cron/src/services/email.service.ts
+++ b/packages/cron/src/services/email.service.ts
@@ -74,14 +74,14 @@ const sendEmail = async (chesToken: string, recipient: Email): Promise<AxiosResp
         let body = ""
 
         // form link
-        const form = recipient.template.includes("shortform")
+        const form = recipient.template.includes("short")
             ? `${process.env.SHORT_FORM}?uid=${uid}&title=${encodeURIComponent(`${recipient.template} redirect`)}&name=${encodeURIComponent(
                   recipient.name
               )}&email=${encodeURIComponent(recipient.email)}&catchment=${catchment}`
             : `${process.env.LONG_FORM}?uid=${uid}&title=${encodeURIComponent(recipient.template)}%20redirect`
 
         // email template
-        if (recipient.template.includes("2")) {
+        if (recipient.template.includes("AC")) {
             body = email2Template.email2("9", uid, encodeURIComponent(recipient.template), recipient.name, form)
         } else {
             body = email1Template.email1("8", uid, encodeURIComponent(recipient.template), recipient.name, form)

--- a/packages/forms-frontend/app/api/form/route.ts
+++ b/packages/forms-frontend/app/api/form/route.ts
@@ -30,13 +30,14 @@ export async function POST(req: NextRequest, res: NextResponse) {
 
         //  check if email is valid
         if (!json.email) throw new Error("Email is required")
+
+        // check if user is allowed to submit a form
         const existing = await prisma.email.findFirst({
             where: {
-                email: json.email
+                uid: json.uid
             }
         })
-
-        if (!existing) throw new Error("Email is not part of the trial")
+        if (!existing || !existing.template.includes("short")) throw new Error("Email is not part of the trial")
 
         //  send email to centre
         const token = await getToken()

--- a/packages/forms-frontend/app/form/page.tsx
+++ b/packages/forms-frontend/app/form/page.tsx
@@ -17,7 +17,7 @@ const Page = () => {
     const router = useRouter()
     const searchParams = useSearchParams()
     const { uid, name, centre, email, catchment } = {
-        uid: Number(searchParams.get("uid")),
+        uid: searchParams.get("uid"),
         name: searchParams.get("amp;name"),
         centre: Number(searchParams.get("amp;centre")) || 1,
         email: searchParams.get("amp;email"),
@@ -61,7 +61,6 @@ const Page = () => {
             toast.error(`Error submitting form: ${message}`)
         },
         onMutate: (newSubmission: any) => {
-            console.log(newSubmission)
             toast.info(
                 `Submitting form to ${
                     centres.data

--- a/packages/forms-frontend/prisma/schema.prisma
+++ b/packages/forms-frontend/prisma/schema.prisma
@@ -9,19 +9,20 @@ datasource db {
 
 model Email {
   id        Int      @id @default(autoincrement())
-  email     String   
+  uid       String   @unique
+  email     String
   template  String   @default("")
   status    String   @default("pending")
   createdAt DateTime @default(now()) @db.Timestamptz(3)
   messageId String   @default("")
   name      String   @default("")
-  catchment  String  @default("")
+  catchment String   @default("")
 }
 
 model Submission {
   id        Int      @id @default(autoincrement())
-  uid       Int      @unique
-  email     String   
+  uid       String   @unique
+  email     String
   createdAt DateTime @default(now())
-  action   String    @default("")
+  action    String   @default("")
 }


### PR DESCRIPTION
- Updated cron job to use a unique uid for each user (fixes matomo issue with repeated IDs)
    - does not seem possible to set a specific pattern for a field in the prisma schema
- Updated template convention to be "Standard short", "Standard long", "AC short", "AC long"
- Error handling to check if a user has the correct template type for form submission