### PR TITLE
TECH-385: Error handling on api route

### DIFF
--- a/packages/forms-frontend/app/api/form/route.ts
+++ b/packages/forms-frontend/app/api/form/route.ts
@@ -37,7 +37,11 @@ export async function POST(req: NextRequest, res: NextResponse) {
                 uid: json.uid
             }
         })
-        if (!existing || !existing.template.includes("short")) throw new Error("Email is not part of the trial")
+        if (!existing || !existing.template.includes("short")) throw new Error("You are not eligible to submit a form")
+
+        // ensure email and catchment are unchanged
+        if (existing.email !== json.email) throw new Error("Email is not part of the trial")
+        if (existing.catchment !== json.catchment) throw new Error(`${json.catchment} is not your catchment`)
 
         //  send email to centre
         const token = await getToken()


### PR DESCRIPTION
- Added checks for email and catchment

The cron tests are failing because I changed the name field in the email templates, but didn't update the tests