### PR TITLE
TECH-398: Added email sent time logging

### DIFF
--- a/packages/cron/prisma/schema.prisma
+++ b/packages/cron/prisma/schema.prisma
@@ -15,6 +15,7 @@ model Email {
   status    String   @default("pending")
   createdAt DateTime @default(now()) @db.Timestamptz(3)
   messageId String   @default("")
+  messageCreatedAt DateTime? @db.Timestamptz(3)
   name      String   @default("")
   catchment String   @default("")
 }

--- a/packages/cron/src/services/email.service.ts
+++ b/packages/cron/src/services/email.service.ts
@@ -40,7 +40,8 @@ const updateEmail = async (id: number, status: string): Promise<Email> =>
             id
         },
         data: {
-            status
+            status,
+            messageCreatedAt: new Date()
         }
     })
 

--- a/packages/cron/src/tests/email.controller.test.ts
+++ b/packages/cron/src/tests/email.controller.test.ts
@@ -15,6 +15,7 @@ jest.mock("../services/email.service", () => ({
             status: "pending",
             name: "Bob Jones",
             messageId: "",
+            messageCreatedAt: null,
             catchment: "31-ES",
             createdAt: "2023-07-26T16:35:17.391Z"
         })
@@ -26,6 +27,7 @@ jest.mock("../services/email.service", () => ({
             status: "sent",
             name: "Bob Jones",
             messageId: "abc-123456",
+            messageCreatedAt: null,
             catchment: "31-ES",
             createdAt: "2023-07-26T16:35:17.391Z"
         })
@@ -44,6 +46,7 @@ jest.mock("../services/email.service", () => ({
         status: "sent",
         name: "Bob Jones",
         messageId: "abc-123456",
+        messageCreatedAt: null,
         catchment: "31-ES",
         createdAt: "2023-07-26T16:35:17.391Z"
     })
@@ -71,6 +74,7 @@ describe("getAndSendEmail", () => {
             status: "pending",
             name: "Bob Jones",
             messageId: "",
+            messageCreatedAt: null,
             catchment: "31-ES",
             createdAt: "2023-07-26T16:35:17.391Z"
         })

--- a/packages/cron/src/tests/email.service.test.ts
+++ b/packages/cron/src/tests/email.service.test.ts
@@ -2,7 +2,18 @@ import emailService from "../services/email.service"
 import prismaMock from "../db/singleton"
 import { chesApi } from "../config/common.config"
 
-const email1 = {
+const email1: {
+    id: number
+    uid: string
+    email: string
+    template: string
+    status: string
+    name: string
+    messageId: string
+    messageCreatedAt: Date | null
+    catchment: string
+    createdAt: Date
+} = {
     id: 1,
     uid: "72z9cri0dy",
     email: "hello@example.net",
@@ -10,11 +21,23 @@ const email1 = {
     status: "completed",
     name: "Trista Dhami",
     messageId: "qwe-234567",
+    messageCreatedAt: null,
     catchment: "01-ES",
     createdAt: new Date()
 }
 
-const email2 = {
+const email2: {
+    id: number
+    uid: string
+    email: string
+    template: string
+    status: string
+    name: string
+    messageId: string
+    messageCreatedAt: Date | null
+    catchment: string
+    createdAt: Date
+} = {
     id: 2,
     uid: "ip31cwmn8c",
     email: "someone@example.com",
@@ -22,11 +45,24 @@ const email2 = {
     status: "pending",
     name: "Bob Jones",
     messageId: "",
+    messageCreatedAt: null,
     catchment: "31-ES",
     createdAt: new Date()
 }
 
-let email3 = {
+let email3: {
+    id: number
+    uid: string
+    email: string
+    template: string
+
+    status: string
+    name: string
+    messageId: string
+    messageCreatedAt: Date | null
+    catchment: string
+    createdAt: Date
+} = {
     id: 3,
     uid: "15eqyowks4",
     email: "testing@example.org",
@@ -34,6 +70,7 @@ let email3 = {
     status: "pending",
     name: "Brian Pham",
     messageId: "",
+    messageCreatedAt: null,
     catchment: "02-ES",
     createdAt: new Date()
 }
@@ -46,6 +83,7 @@ const updatedEmail3 = {
     status: "sent",
     name: "Brian Pham",
     messageId: "xyz-456789",
+    messageCreatedAt: new Date(),
     catchment: "02-ES",
     createdAt: new Date()
 }
@@ -92,7 +130,8 @@ describe("updateEmail", () => {
                 id: 3
             },
             data: {
-                status: "sent"
+                status: "sent",
+                messageCreatedAt: new Date()
             }
         })
         expect(email3.id).toEqual(3)
@@ -109,6 +148,7 @@ describe("updateEmail", () => {
             status: "pending",
             name: "Brian Pham",
             messageId: "",
+            messageCreatedAt: null,
             catchment: "02-ES",
             createdAt: new Date()
         }

--- a/packages/forms-frontend/prisma/schema.prisma
+++ b/packages/forms-frontend/prisma/schema.prisma
@@ -8,15 +8,16 @@ datasource db {
 }
 
 model Email {
-  id        Int      @id @default(autoincrement())
-  uid       String   @unique
-  email     String
-  template  String   @default("")
-  status    String   @default("pending")
-  createdAt DateTime @default(now()) @db.Timestamptz(3)
-  messageId String   @default("")
-  name      String   @default("")
-  catchment String   @default("")
+  id               Int       @id @default(autoincrement())
+  uid              String    @unique
+  email            String
+  template         String    @default("")
+  status           String    @default("pending")
+  createdAt        DateTime  @default(now()) @db.Timestamptz(3)
+  messageId        String    @default("")
+  name             String    @default("")
+  catchment        String    @default("")
+  messageCreatedAt DateTime? @db.Timestamptz(3)
 }
 
 model Submission {


### PR DESCRIPTION
Description of changes:
- On update to the email, the email sent time is logged as messageCreatedAt
- This has been reflected in dev and test OS env