### PR TITLE
fix cron job timing

### DIFF
--- a/packages/cron/src/app.ts
+++ b/packages/cron/src/app.ts
@@ -30,7 +30,7 @@ app.get("/", (req: Express.Request, res: any) => {
 // Cron job to schedule email delivery
 // between 8AM to 6PM PST, every 5 minutes, send 60 emails
 // Note: maximum recommended usage is 60 emails per minute
-cronService.startJob("* */5 * 8-18 * 1-5", emailController.getAndSendEmail)
+cronService.startJob("* */5 8-17 * * 1-5", emailController.getAndSendEmail)
 
 const port = process.env.PORT || "8002"
 app.listen(port, () => {

--- a/packages/cron/src/templates/email1.template.ts
+++ b/packages/cron/src/templates/email1.template.ts
@@ -28,7 +28,7 @@ const email1 = (
 <body style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 15px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; margin: 0; padding: 0; border: 0;">
 
 <!-- Matomo Image Tracker-->
-<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=${matomoId}&amp;rec=1&amp;uid=${uid}&amp;_rcn=${campaign}&amp;action_name=${campaign}Email" style="border:0" alt="" />
+<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=${matomoId}&amp;rec=1&amp;uid=${uid}&amp;_rcn=${campaign}&amp;action_name=${campaign}%20Email" style="border:0" alt="" />
 <!-- End Matomo -->
   
 <table valign="top" style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 15px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; border-spacing: 0px; border-collapse: collapse; margin: 0; padding: 0; border: 0;">

--- a/packages/cron/src/templates/email2.template.ts
+++ b/packages/cron/src/templates/email2.template.ts
@@ -28,7 +28,7 @@ const email2 = (
 <body style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 15px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; margin: 0; padding: 0; border: 0;">
 
 <!-- Matomo Image Tracker-->
-<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=${matomoId}&amp;rec=1&amp;uid=${uid}&amp;_rcn=${campaign}&amp;action_name=${campaign}Email" style="border:0" alt="" />
+<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=${matomoId}&amp;rec=1&amp;uid=${uid}&amp;_rcn=${campaign}&amp;action_name=${campaign}%20Email" style="border:0" alt="" />
 <!-- End Matomo -->
   
 <table valign="top" style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 15px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; border-spacing: 0px; border-collapse: collapse; margin: 0; padding: 0; border: 0;">

--- a/packages/cron/src/templates/previous.template.ts
+++ b/packages/cron/src/templates/previous.template.ts
@@ -26,7 +26,7 @@ const previousEmail = (
 <body style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 15px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; margin: 0; padding: 0; border: 0;">
 
 <!-- Matomo Image Tracker-->
-<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=${matomoId}&amp;rec=1&amp;uid=${uid}&amp;_rcn=${campaign}&amp;action_name=${campaign}Email" style="border:0" alt="" />
+<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=${matomoId}&amp;rec=1&amp;uid=${uid}&amp;_rcn=${campaign}&amp;action_name=${campaign}" style="border:0" alt="" />
 <!-- End Matomo -->
   
 <table valign="top" style="outline: 0; width: 100%; min-width: 100%; height: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-family: Helvetica, Arial, sans-serif; line-height: 24px; font-weight: normal; font-size: 15px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; border-spacing: 0px; border-collapse: collapse; margin: 0; padding: 0; border: 0;">

--- a/packages/cron/src/tests/templates.test.ts
+++ b/packages/cron/src/tests/templates.test.ts
@@ -6,7 +6,7 @@ describe("email1 template is filled in correctly", () => {
     const emailBody = email1Template.email1(
         "8",
         "1",
-        encodeURIComponent("Standard short redirect"),
+        encodeURIComponent("Standard short"),
         "Trista Dhami",
         `${process.env.SHORT_FORM}?uid=1&title=${encodeURIComponent("Standard short redirect")}&name=${encodeURIComponent("Trista Dhami")}`,
         false
@@ -15,7 +15,7 @@ describe("email1 template is filled in correctly", () => {
     it("Matomo img tracker", () => {
         expect(emailBody).toEqual(
             expect.stringContaining(
-                '<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=8&amp;rec=1&amp;uid=1&amp;_rcn=Standard%20short%20redirect&amp;action_name=Email" style="border:0" alt="" />'
+                '<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=8&amp;rec=1&amp;uid=1&amp;_rcn=Standard%20short&amp;action_name=Standard%20short%20Email" style="border:0" alt="" />'
             )
         )
     })
@@ -35,7 +35,7 @@ describe("email2 template is filled in correctly", () => {
     const emailBody = email2Template.email2(
         "9",
         "2",
-        encodeURIComponent("AC short redirect"),
+        encodeURIComponent("AC short"),
         "Brian Pham",
         `${process.env.SHORT_FORM}?uid=2&title=${encodeURIComponent("AC short redirect")}&name=${encodeURIComponent("Brian Pham")}`,
         false
@@ -44,7 +44,7 @@ describe("email2 template is filled in correctly", () => {
     it("Matomo img tracker", () => {
         expect(emailBody).toEqual(
             expect.stringContaining(
-                '<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=9&amp;rec=1&amp;uid=2&amp;_rcn=AC%20short%20redirect&amp;action_name=Email" style="border:0" alt="" />'
+                '<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=9&amp;rec=1&amp;uid=2&amp;_rcn=AC%20short&amp;action_name=AC%20short%20Email" style="border:0" alt="" />'
             )
         )
     })
@@ -70,7 +70,7 @@ describe("previousEmail template is filled in correctly", () => {
     it("Matomo img tracker", () => {
         expect(emailBody).toEqual(
             expect.stringContaining(
-                '<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=12&amp;rec=1&amp;uid=3&amp;_rcn=Previous%20WorkBC%20Client%20Email&amp;action_name=Email" style="border:0" alt="" />'
+                '<img referrerpolicy="no-referrer-when-downgrade" src="https://elmsd-matomo.apps.silver.devops.gov.bc.ca/matomo.php?idsite=12&amp;rec=1&amp;uid=3&amp;_rcn=Previous%20WorkBC%20Client%20Email&amp;action_name=Previous%20WorkBC%20Client%20Email" style="border:0" alt="" />'
             )
         )
     })


### PR DESCRIPTION
- Added a missing space in the Matomo image tracker's action_name (in all email templates)
- Updated email template tests for Matomo names
- Every five minutes the cron job runs every second (during the hours 8AM to 6PM PST, from Monday to Friday)
    - i.e. the first jobs of the day are at 08:00:00, 8:00:01, 08:00:02, ..., 08:00:59
    - the last jobs of the day are at 17:55:00, 17:55:01, 17:55:02, ..., 17:55:59
    - The job runs 7,200 times per day

There were two fixes.  First, the hours parameter was in the spot for the days of the month parameter. Second, the job was scheduled for 11 hours instead of 10 (it was running until the end of the 18th hour, while the intention was to go until the end of the 17th hour).